### PR TITLE
Add `phylum` to system path

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -115,11 +115,20 @@ runs:
         echo 'exiting with 0 since package dependency files were not modified'
         echo '0' > $HOME/returncode.txt
 
+    - name: Update system path
+      shell: bash
+      run: |
+        # In version 2.2.0 and older, the binary is installed at "$HOME/.phylum". But newer versions use "$HOME/.local/bin"
+        if [ -f "$HOME/.phylum/phylum" -a -x "$HOME/.phylum/phylum" ]; then
+          echo "$HOME/.phylum" >> $GITHUB_PATH
+        else
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+        fi
+
     - name: Analyze project lockfile with phylum CLI
       shell: bash
       if: "!contains(steps.get-prtype.outputs.prtype, 'NA')"
       run: |
-        export PATH="$HOME/.phylum:$PATH"
         pushd $GITHUB_WORKSPACE || exit 11
         phylum analyze -l $PHYLUM_LABEL ${{ steps.get-prtype.outputs.prtype }} --verbose --json > ~/phylum_analysis.json
         echo "[*] Analyzed ${{ steps.get-prtype.outputs.prtype }} under label ${PHYLUM_LABEL} and wrote results to ~/phylum_analysis.json"


### PR DESCRIPTION
This is a direct copy of the same fix made in [phylum-dev/install-phylum-latest-action PR #13](https://github.com/phylum-dev/install-phylum-latest-action/pull/13)

This isn't exactly fixing something that was broken...just making it better / more robust. That is, the action was working before this change...but that is presumed to only be the case b/c `$HOME/.local/bin` is _already_ in the `$GITHUB_PATH`.