### PR TITLE
perf: use GHCR hosted docker image

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,7 @@ Here's how to set up `phylum-analyze-pr-action` for local development.
     ```yaml
     # Change this entry in the `action.yml` file to point to your image. Reference:
     # https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsimage
-    image: docker://phylumio/phylum-ci:latest
+    image: docker://ghcr.io/phylum-dev/phylum-ci:latest
     ```
 
 4. Commit your changes and push your branch to GitHub:

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The pre-requisites for using this image are:
 * Ability to run a [Docker container action][container]
   * GitHub-hosted runners must use an Ubuntu runner
   * Self-hosted runners must use a Linux operating system and have Docker installed
-* Access to the [phylumio/phylum-ci Docker image](https://hub.docker.com/r/phylumio/phylum-ci/tags)
+* Access to the `phylum-dev/phylum-ci` Docker image from the [GitHub Container Registry][package]
 * A [GitHub token][gh_token] with API access
   * Can be the default `GITHUB_TOKEN` provided automatically at the start of each workflow run
     * Needs at least write access for `pull-requests` scope - see [documentation][scopes]
@@ -66,6 +66,7 @@ The pre-requisites for using this image are:
     [`phylum project create`](https://docs.phylum.io/docs/phylum_project_create) command documentation
 
 [container]: https://docs.github.com/en/actions/creating-actions/creating-a-docker-container-action
+[package]: https://github.com/phylum-dev/phylum-ci/pkgs/container/phylum-ci
 [gh_token]: https://docs.github.com/en/actions/security-guides/automatic-token-authentication
 [scopes]: https://docs.github.com/en/developers/apps/building-oauth-apps/scopes-for-oauth-apps#available-scopes
 [PAT]: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ inputs:
     default: phylum-ci
 runs:
   using: docker
-  image: docker://phylumio/phylum-ci:latest
+  image: docker://ghcr.io/phylum-dev/phylum-ci:latest
   entrypoint: entrypoint.sh
   env:
     GITHUB_TOKEN: ${{ inputs.github_token }}


### PR DESCRIPTION
Pull the `phylum-ci` Docker image from the GitHub Container Registry (ghcr.io) instead of Docker Hub. This will allow for unlimited transfers for consumers of the action, regardless of whether they are a public/private repo or using self-hosted runners instead of GitHub-hosted runners.

Closes #18

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
- [ ] ~Have you created sufficient tests?~
  - Tested with `TestGHA` repo...slightly modified locally and with some tweaks to get past the (transient?) "error creating client" issue
- [x] Have you updated all affected documentation?
