### PR TITLE
docs: add verbose logging examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,8 @@ view the [script options output][script_options] for the latest release.
           # the active policy set at the Phylum project level.
           # This entry does not have to be specified since it is the default.
           cmd: phylum-ci
+          # Provide debug level output
+          cmd: phylum-ci -vv
           # Consider all dependencies in analysis results instead of just the newly added ones.
           # The default is to only analyze newly added dependencies, which can be useful for
           # existing code bases that may not meet established policy rules yet,
@@ -260,6 +262,7 @@ view the [script options output][script_options] for the latest release.
           # Mix and match for your specific use case.
           cmd: |
             phylum-ci \
+              -vv \
               --lockfile requirements-dev.txt \
               --lockfile requirements-prod.txt path/to/lock.file \
               --all-deps

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,9 @@ inputs:
     default: phylum-ci
 runs:
   using: docker
-  image: docker://ghcr.io/phylum-dev/phylum-ci:latest
+  # TODO: Revert this before merging!!!
+  image: docker://maxrake/phylum-ci:add_logging
+  # image: docker://ghcr.io/phylum-dev/phylum-ci:latest
   entrypoint: entrypoint.sh
   env:
     GITHUB_TOKEN: ${{ inputs.github_token }}

--- a/action.yml
+++ b/action.yml
@@ -27,9 +27,7 @@ inputs:
     default: phylum-ci
 runs:
   using: docker
-  # TODO: Revert this before merging!!!
-  image: docker://maxrake/phylum-ci:add_logging
-  # image: docker://ghcr.io/phylum-dev/phylum-ci:latest
+  image: docker://ghcr.io/phylum-dev/phylum-ci:latest
   entrypoint: entrypoint.sh
   env:
     GITHUB_TOKEN: ${{ inputs.github_token }}


### PR DESCRIPTION
This PR is related to https://github.com/phylum-dev/phylum-ci/pull/247 in that it makes the same documentation updates to add verbose logging examples.

**NOTE:** This PR should not be merged in until all of the following are complete:

* [x] https://github.com/phylum-dev/phylum-ci/pull/247 has been approved _and included_ in a `phylum-ci` release
  * Any changes to docs made in that PR should be replicated here
* [x] The use of the `maxrake/phylum-ci:add_logging` image has been reverted
  * This is only in place for testing while the other PR is up