### PR TITLE
docs: update dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ If not explicitly specified, an attempt will be made to automatically detect loc
 strict dependencies. In these cases, it is best to specify explicit lockfile paths by using the `phylum-ci --lockfile`
 option. The list of currently supported lockfiles can be found in the [Phylum Knowledge Base][supported_lockfiles].
 
-[supported_lockfiles]: https://docs.phylum.io/docs/analyzing-dependencies
+[supported_lockfiles]: https://docs.phylum.io/docs/supported_lockfiles
 
 ## Getting Started
 


### PR DESCRIPTION
With the recent release of the CLI v5.7.1, documentation was updated. The big changes are:

* https://docs.phylum.io/docs/analyzing-dependencies was replaced by https://docs.phylum.io/docs/analyzing_dependencies and https://docs.phylum.io/docs/supported_lockfiles
* https://docs.phylum.io/docs/lockfile-generation was replaced by https://docs.phylum.io/docs/lockfile_generation

This PR updates the links in this repository to match.

Since this change is only to the `README.md` file, no new tag or release is needed. This is because the action documentation is updated automatically to refer to what is on `main`.
