### PR TITLE
docs: add support for `pull_request_target` events

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@
 ---
 name: Phylum Analyze PR
 author: Phylum, Inc. <engineering@phylum.io>
-description: Analyze dependencies in a pull request with Phylum
+description: Analyze dependencies with Phylum to protect your code against increasingly sophisticated attacks and get peace of mind to focus on your work
 branding:
   icon:  check-circle
   color: blue


### PR DESCRIPTION
This is the documentation update that goes with phylum-dev/phylum-ci#331

Changes made include:

* Update the action tagline and marketplace description
  * Provide a better value proposition
* Add information about supporting pull requests from repository forks
  * Pre-requisite event for workflow triggers
  * How to check out the PR repository
* Add warnings about the security implications of supporting PR forks
  * Provide links explaining the risks
  * Provide guidance on how to use the Phylum GHA in a secure manner
* Change more instances of `lock.file` to `dependency.file`