### PR TITLE
docs: account for breaking `phylum-ci` changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,25 +331,25 @@ view the [script options output][script_options] for the latest release.
           cmd: phylum-ci --force-analysis
           # Force analysis for all dependencies in a manifest file. This is especially useful
           # for *workspace* manifest files where there is no companion lockfile (e.g., libraries).
-          cmd: phylum-ci --force-analysis --all-deps --lockfile Cargo.toml
+          cmd: phylum-ci --force-analysis --all-deps --depfile Cargo.toml
           # Some lockfile types (e.g., Python/pip `requirements.txt`) are ambiguous in that
           # they can be named differently and may or may not contain strict dependencies.
-          # In these cases it is best to specify an explicit path, either with the `--lockfile`
+          # In these cases it is best to specify an explicit path, either with the `--depfile`
           # option or in a `.phylum_project` file. The easiest way to do that is with the
           # Phylum CLI, using the `phylum init` command (https://docs.phylum.io/docs/phylum_init)
           # and committing the generated `.phylum_project` file.
-          cmd: phylum-ci --lockfile requirements-prod.txt
+          cmd: phylum-ci --depfile requirements-prod.txt
           # Specify multiple explicit dependency file paths
-          cmd: phylum-ci --lockfile requirements-prod.txt path/to/dependency.file
+          cmd: phylum-ci --depfile requirements-prod.txt path/to/dependency.file
           # Install a specific version of the Phylum CLI.
           cmd: phylum-ci --phylum-release 4.8.0 --force-install
           # Mix and match for your specific use case.
           cmd: |
             phylum-ci \
               -vv \
-              --lockfile requirements-dev.txt \
-              --lockfile requirements-prod.txt path/to/dependency.file \
-              --lockfile Cargo.toml \
+              --depfile requirements-dev.txt \
+              --depfile requirements-prod.txt path/to/dependency.file \
+              --depfile Cargo.toml \
               --force-analysis \
               --all-deps
 ```


### PR DESCRIPTION
phylum-dev/phylum-ci#364 introduced breaking changes. The `--lockfile`/`-l` argument was changed to `--depfile`/`-d`. This change updates the docs to match. The PR should not be merged until a `phylum-ci` release with the changes is out.
