### PR TITLE
docs: account for audit mode and skipping comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,8 +304,7 @@ view the [script options output][script_options] for the latest release.
           # Consider using a bot or group account for this token.
           phylum_token: ${{ secrets.PHYLUM_TOKEN }}
 
-          # NOTE: These are examples. Only one `github_token` entry line is expected,
-          #       and only with comment generation enabled.
+          # NOTE: These are examples. At most one `github_token` entry line is needed.
           #
           # Use the default `GITHUB_TOKEN` provided automatically at the start of each workflow run.
           # This entry does not have to be specified since it is the default.


### PR DESCRIPTION
This change updates the documentation now that the GitHub token can be optional since it is now possible to skip comment generation with a flag or implicitly when audit mode is enabled.

## Notes

* This PR should not be merged until https://github.com/phylum-dev/phylum-ci/pull/400 is merged and a `phylum-ci` release containing it has been created
* ~~A new tag and release should be created when this feature is merged to `main`~~