### PR TITLE
docs: add exclusion examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,14 @@ view the [script options output][script_options] for the latest release.
           cmd: phylum-ci --depfile requirements-prod.txt
           # Specify multiple explicit dependency file paths.
           cmd: phylum-ci --depfile requirements-prod.txt path/to/dependency.file
+          # Exclude dependency files by glob-style pattern.
+          cmd: phylum-ci --exclude "requirements-*.txt"
+          # Specify multiple exclusion patterns.
+          cmd: phylum-ci --exclude "build.gradle" "tests/fixtures/*"
+          cmd: |
+            phylum-ci \
+              --exclude "build.gradle" \
+              --exclude "tests/fixtures/*"
           # Perform analysis as part of a group-owned project.
           # A paid account is needed to use groups: https://phylum.io/pricing
           cmd: phylum-ci --group my_group

--- a/README.md
+++ b/README.md
@@ -339,14 +339,14 @@ view the [script options output][script_options] for the latest release.
           cmd: phylum-ci --depfile requirements-prod.txt
           # Specify multiple explicit dependency file paths.
           cmd: phylum-ci --depfile requirements-prod.txt path/to/dependency.file
-          # Exclude dependency files by glob-style pattern.
+          # Exclude dependency files by gitignore-style pattern.
           cmd: phylum-ci --exclude "requirements-*.txt"
           # Specify multiple exclusion patterns.
           cmd: phylum-ci --exclude "build.gradle" "tests/fixtures/*"
           cmd: |
             phylum-ci \
               --exclude "/requirements-*.txt" \
-              --exclude "build.gradle" "tests/fixtures/*"
+              --exclude "build.gradle" "fixtures/"
           # Perform analysis as part of a group-owned project.
           # A paid account is needed to use groups: https://phylum.io/pricing
           cmd: phylum-ci --group my_group

--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ view the [script options output][script_options] for the latest release.
           # Exclude dependency files by gitignore-style pattern.
           cmd: phylum-ci --exclude "requirements-*.txt"
           # Specify multiple exclusion patterns.
-          cmd: phylum-ci --exclude "build.gradle" "tests/fixtures/*"
+          cmd: phylum-ci --exclude "build.gradle" "tests/fixtures/"
           cmd: |
             phylum-ci \
               --exclude "/requirements-*.txt" \

--- a/README.md
+++ b/README.md
@@ -345,8 +345,8 @@ view the [script options output][script_options] for the latest release.
           cmd: phylum-ci --exclude "build.gradle" "tests/fixtures/*"
           cmd: |
             phylum-ci \
-              --exclude "build.gradle" \
-              --exclude "tests/fixtures/*"
+              --exclude "/requirements-*.txt" \
+              --exclude "build.gradle" "tests/fixtures/*"
           # Perform analysis as part of a group-owned project.
           # A paid account is needed to use groups: https://phylum.io/pricing
           cmd: phylum-ci --group my_group


### PR DESCRIPTION
This PR updates the documentation for the GitHub Action to
match the examples provided in phylum-dev/phylum-ci#462. It
should not be merged until after the changes from that PR
have been approved, merged, and a release created from it.

Related to phylum-dev/roadmap#462
