### PR TITLE
docs: add exit code information

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ view the [script options output][script_options] for the latest release.
 ### Exit Codes
 
 The Phylum Analyze PR action will return a zero (0) exit code when it completes successfully and a non-zero code
-otherwise. The full and current list of exit codes, with explanations, is [documented here][exit_codes].
+otherwise. The full and current list of exit codes is [documented here][exit_codes].
 
 [exit_codes]: https://github.com/phylum-dev/phylum-ci?tab=readme-ov-file#exit-codes
 

--- a/README.md
+++ b/README.md
@@ -365,6 +365,13 @@ view the [script options output][script_options] for the latest release.
               --all-deps
 ```
 
+### Exit Codes
+
+The Phylum Analyze PR action will return a zero (0) exit code when it completes successfully and a non-zero code
+otherwise. The full and current list of exit codes, with explanations, is [documented here][exit_codes].
+
+[exit_codes]: https://github.com/phylum-dev/phylum-ci?tab=readme-ov-file#exit-codes
+
 ## Example Comments
 
 > **NOTE:** Comments will not be shown when in audit mode or when comments are explicitly skipped.


### PR DESCRIPTION
This PR is meant to go with the changes made in https://github.com/phylum-dev/phylum-ci/pull/465

It should not be merged until that one is.
