### PR TITLE
docs: update exit code section

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,8 +378,8 @@ view the [script options output][script_options] for the latest release.
 ### Exit Codes
 
 The Phylum Analyze PR action will return a zero (0) exit code when it completes successfully and a non-zero code
-otherwise. The full and current list of exit codes is [documented here][exit_codes] and [options exist][script_options]
-to be loose with setting them.
+otherwise. The full and current list of exit codes is [documented here][exit_codes] and "Output Modification"
+[options exist][script_options] to be strict or loose with setting them.
 
 [exit_codes]: https://github.com/phylum-dev/phylum-ci#exit-codes
 


### PR DESCRIPTION
This PR updates the documentation for the GitHub Action to match the wording provided in phylum-dev/phylum-ci#510.
